### PR TITLE
Add Blender 4.x compatibility for materials.py

### DIFF
--- a/materials.py
+++ b/materials.py
@@ -47,7 +47,10 @@ for mat in targetMats:
     # Create principled shader
     prin = nodes.new("ShaderNodeBsdfPrincipled")
     prin.location = 300, 0
-    prin.inputs["Specular"].default_value = 0
+    if int(bpy.app.version_string.split('.')[0]) >= 4:
+        prin.inputs["Specular IOR Level"].default_value = 0
+    else:
+        prin.inputs["Specular"].default_value = 0
 
     # Create output
     out = nodes.new("ShaderNodeOutputMaterial")


### PR DESCRIPTION
I added compatibility with Blender 4.x to the material.py script.  
Thanks @rudzik8 for the fix (see https://github.com/random-geek/meshport/issues/12)!