### PR TITLE
Improve Meshport: Texture Embedding, Webhook, and Monitoring

### DIFF
--- a/export.lua
+++ b/export.lua
@@ -24,6 +24,18 @@
 local S = meshport.S
 local vec = vector.new -- Makes defining tables of vertices a little less painful.
 
+local has_monitoring = minetest.get_modpath("monitoring")
+
+local metric_meshport_exported
+
+if has_monitoring then
+	metric_meshport_exported = monitoring.counter(
+		"meshport_mesh_exported",
+		"Number of exported mesh"
+	)
+end
+
+
 --[[
 	THE CUBIC NODE PRIORITY SYSTEM
 
@@ -782,7 +794,7 @@ local function cleanup_resources()
 end
 
 
-function meshport.create_mesh(playerName, p1, p2, path)
+function meshport.create_mesh(playerName, p1, p2, path, folderName)
 	meshport.log(playerName, "info", S("Generating mesh..."))
 	initialize_resources()
 
@@ -816,7 +828,11 @@ function meshport.create_mesh(playerName, p1, p2, path)
 	core.mkdir(path)
 	mesh:write_obj(path)
 	mesh:write_mtl(path, playerName)
+	mesh:call_webhook(folderName, playerName)
 
 	cleanup_resources()
 	meshport.log(playerName, "info", S("Finished. Saved to @1", path))
+	if has_monitoring then
+		metric_meshport_exported.inc(1)
+	end
 end

--- a/init.lua
+++ b/init.lua
@@ -23,6 +23,7 @@ meshport = {
 }
 
 modpath = core.get_modpath("meshport")
+dofile(modpath .. "/settings.lua")
 dofile(modpath .. "/utils.lua")
 dofile(modpath .. "/mesh.lua")
 dofile(modpath .. "/parse_obj.lua")
@@ -31,6 +32,14 @@ dofile(modpath .. "/export.lua")
 
 local S = meshport.S
 local vec = vector.new
+
+local http = core.request_http_api and core.request_http_api()
+if core.get_modpath("qos") then
+	-- use qos-wrapped http
+	http = QoS(http, 2)
+end
+
+meshport.http = http
 
 core.register_privilege("meshport", S("Can save meshes with Meshport."))
 
@@ -321,6 +330,6 @@ core.register_chatcommand("meshport", {
 		end
 
 		local path = mpPath .. "/" .. folderName
-		meshport.create_mesh(playerName, playerData.pos[1], playerData.pos[2], path)
+		meshport.create_mesh(playerName, playerData.pos[1], playerData.pos[2], path, folderName)
 	end,
 })

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -21,3 +21,4 @@ Generating mesh...
 Finished. Saved to @1
 Ignoring texture modifers in material "@1".
 Could not find texture "@1". Using a dummy material instead.
+[meshport] webhook post failed with code "@1"

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,3 @@
 name = meshport
 description = Easily export areas in Luanti to meshes for 3D rendering.
+optional_depends = qos, monitoring

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,36 @@
+meshport.config = {}
+
+-- taken from https://github.com/minetest-mods/areas/
+local function setting(name, tp, default, config)
+	local full_name = core.get_current_modname().."." .. name
+	local value
+	if tp == "bool" then
+		value = core.settings:get_bool(full_name)
+		default = value == nil and core.is_yes(default)
+	elseif tp == "string" then
+		value = core.settings:get(full_name)
+	elseif tp == "v3f" then
+		value = core.setting_get_pos(full_name)
+		default = value == nil and core.string_to_pos(default)
+	elseif tp == "float" or tp == "int" then
+		value = tonumber(core.settings:get(full_name))
+		local v, other = default:match("^(%S+) (.+)")
+		default = value == nil and tonumber(other and v or default)
+	else
+		error("Cannot parse setting type " .. tp)
+	end
+
+	if value == nil then
+		value = default
+		assert(default ~= nil, "Cannot parse default for " .. full_name)
+	end
+	--print("add", name, default, value)
+	config[name] = value
+end
+
+--------------
+-- Settings --
+--------------
+
+setting("webhook_url", "string", "", meshport.config)
+setting("embed_textures", "bool", false, meshport.config)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+meshport.webhook_url (Webhook url to notify of an export) string 
+meshport.embed_textures (Embed textures or not) bool false


### PR DESCRIPTION
This pull request introduces several enhancements to Meshport:  

1. **Embedded Textures in Exported Folder**  
   - Adds an option to include texture files directly within the exported `.obj` folder.  
   - Ensures the exported folder is self-contained, making it easier to transfer to another environment for post-processing.  

2. **Webhook Integration for Export Events**  
   - Implements a webhook call to notify an external application when an export occurs.  
   - Enables automation and workflow integration based on 3D model exports from Luanti.  
   - Note: This is a basic implementation that only signals the exported folder and the player.  

3. **Optional Monitoring Integration**  
   - Adds an optional dependency on [`[monitoring](https://github.com/minetest-monitoring/monitoring)`](https://github.com/minetest-monitoring/monitoring).  
   - Provides a basic indicator of the number of exported meshes.  

4. **Configuration Options**  
   - Introduces two new settings in `minetest.conf`:  
     - `webhook_url`: Defines the webhook endpoint for export notifications.  
     - `embed_textures`: Controls whether textures are included in the exported folder.  

These changes improve portability, workflow automation, and monitoring capabilities. Let me know if any adjustments are needed! 🚀  
